### PR TITLE
Generate strings from floats centrally

### DIFF
--- a/SmartRegulator/AltReg_CAN.cpp
+++ b/SmartRegulator/AltReg_CAN.cpp
@@ -26,6 +26,7 @@
 #include "AltReg_CAN.h"
 #include <NMEA2000_CAN.h>                                   // https://github.com/ttlappalainen
 #include "Alternator.h"
+#include "Types.h"
 #include "Sensors.h"
 #include "Flash.h"
 

--- a/SmartRegulator/Alternator.cpp
+++ b/SmartRegulator/Alternator.cpp
@@ -23,6 +23,7 @@
 #include "Config.h"
 #include "Alternator.h"
 #include "AltReg_Serial.h"
+#include "Types.h"
 #include "Sensors.h"
 
 
@@ -1316,9 +1317,9 @@ void manage_ALT()  {
      if ((sendDebugString == true) && (--SDMCounter  <= 0)) {
 
 #ifdef SYSTEMCAN
-             snprintf_P(charBuffer,OUTBOUND_BUFF_SIZE, PSTR("DBG;,%d.%03d, ,%d,%d, ,%d, ,%d,%d,%d,%d,%d, ,%d,%d, %c,%d.%03d,%d.%01d, ,%d,%d,%d,  ,%d,%d,%d,%d.%03d\r\n"),
+       snprintf_P(charBuffer,OUTBOUND_BUFF_SIZE, PSTR("DBG;,%d.%03d, ,%d,%d, ,%d, ,%d,%d,%d,%d,%d, ,%d,%d, %c,%s,%s, ,%d,%d,%d,  ,%d,%d,%d,%s\r\n"),
 #else
-             snprintf_P(charBuffer,OUTBOUND_BUFF_SIZE, PSTR("DBG;,%d.%03d, ,%d,%d, ,%d, ,%d,%d,%d,%d,%d, ,%d,%d, %c,%d.%03d,%d.%01d, ,%d,%d,%d\r\n"),
+       snprintf_P(charBuffer,OUTBOUND_BUFF_SIZE, PSTR("DBG;,%d.%03d, ,%d,%d, ,%d, ,%d,%d,%d,%d,%d, ,%d,%d, %c,%s,%s, ,%d,%d,%d\r\n"),
 #endif
              (int) (enteredMills / 1000UL),                                                             // Timestamp - Seconds
              (int) (enteredMills % 1000),                                                               // time-stamp - 1000th of seconds
@@ -1342,24 +1343,16 @@ void manage_ALT()  {
 
                   //    --- Pick one  ----
   /*                 'A',
-                  (int)    measuredAltVolts,                                                            // Alternator Voltage to 1/1000th of a volt
-                  frac2int(measuredAltVolts, 1000),
-                  (int)    measuredAltAmps,                                                             // Alternator Amps to 1/10th of an amp
-                  frac2int(measuredAltAmps, 10),
-*/
- /*                 'B',
-                  (int)    measuredBatVolts,                                                            // Battery Voltage to 1/1000th of a volt
-                  frac2int(measuredBatVolts, 1000),
-                  (int)    measuredBatAmps,                                                             // Battery Amps to 1/10th of an amp
-                  frac2int(measuredBatAmps, 10),
-*/
-                 'P',
-                  (int)    persistentBatVolts,                                                          // Persistent Voltage to 1/1000th of a volt
-                  frac2int(persistentBatVolts, 1000),
-                  (int)    persistentBatAmps,                                                           // Persistent Amps to 1/10th of an amp
-                  frac2int(persistentBatAmps, 10),
-
-
+                  floatString(measuredAltVolts, 3),
+                  floatString(measuredAltAmps, 1),
+  */
+   /*                 'B',
+                  floatString(measuredBatVolts, 3),
+                  floatString(measuredBatAmps, 1),
+  */
+                   'P',
+                  floatString(persistentBatVolts, 3),
+                  floatString(persistentBatAmps, 1),
 
                   usingEXTAmps,
                   thresholdPWMvalue,
@@ -1369,8 +1362,7 @@ void manage_ALT()  {
                   , fetch_CAN_localID(),
                   CAN_RBM_sourceID,
                   ALT_Per_Util(),
-                  (int)    CAN_RBM_voltsOffset,                                                             // Remote Battery Voltage adjustment value to 1/1000th of a volt
-                  frac2int(CAN_RBM_voltsOffset, 1000)
+                  floatString(CAN_RBM_voltsOffset, 3)
 #endif
 
                    );

--- a/SmartRegulator/Flash.h
+++ b/SmartRegulator/Flash.h
@@ -26,6 +26,7 @@
 
 #include <Arduino.h>
 #include "Config.h"                                               // Pick up the specific structures and their sizes for this program.
+#include "Types.h"
 #include "Sensors.h"
 #include "CPE.h"   
 #include "Alternator.h"

--- a/SmartRegulator/Sensors.cpp
+++ b/SmartRegulator/Sensors.cpp
@@ -20,6 +20,7 @@
 //
 
 #include "Config.h"
+#include "Types.h"
 #include "Sensors.h"
 #include "Alternator.h"
 #include "AltReg_CAN.h"

--- a/SmartRegulator/SmartRegulator.ino
+++ b/SmartRegulator/SmartRegulator.ino
@@ -118,6 +118,7 @@
 #include "CPE.h"
 #include "AltReg_Serial.h"
 #include "Alternator.h"
+#include "Types.h"
 #include "Sensors.h"
 #include "AltReg_CAN.h"
 

--- a/SmartRegulator/Types.cpp
+++ b/SmartRegulator/Types.cpp
@@ -1,0 +1,48 @@
+//      Types.cpp
+//
+//      Copyright (c) 2016, 2017 by William A. Thomason.      http://arduinoalternatorregulator.blogspot.com/
+//
+//
+//
+//              This program is free software: you can redistribute it and/or modify
+//              it under the terms of the GNU General Public License as published by
+//              the Free Software Foundation, either version 3 of the License, or
+//              (at your option) any later version.
+//
+//              This program is distributed in the hope that it will be useful,
+//              but WITHOUT ANY WARRANTY; without even the implied warranty of
+//              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//              GNU General Public License for more details.
+//
+//              You should have received a copy of the GNU General Public License
+//              along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+//
+
+#include <Arduino.h>
+#include "Types.h"
+
+// floatString converts a float to a string
+// We return one of a set of static buffers
+char *floatString(float v, unsigned char decimals) {
+    const int OUTPUT_BUFS = 6;  // maximum number of floats in a single sprintf
+    const int MAX_OUTPUT = 13;  // largest possible output string
+    static char outputBuffers[OUTPUT_BUFS][MAX_OUTPUT+1];
+    int callCount;
+
+    char *pos = outputBuffers[++callCount % OUTPUT_BUFS];
+    char *opos = pos;
+    if (v < 0) {
+	    *(opos++) = '-';
+	    v = -v;
+    }
+    int mult = 1;
+    int multleft = decimals;
+    while(multleft--) {
+	    mult *= 10;
+    }
+    char format[9];
+    snprintf_P(format, 9, PSTR("%%d.%%0%dd"), decimals);
+    snprintf_P(opos, MAX_OUTPUT, format, (int)v, (int)((v - (int)v) * mult));
+    return pos;
+}

--- a/SmartRegulator/Types.h
+++ b/SmartRegulator/Types.h
@@ -1,0 +1,21 @@
+//      Types.h
+//
+//      Copyright (c) 2016, 2017 by William A. Thomason.      http://arduinoalternatorregulator.blogspot.com/
+//
+//
+//
+//              This program is free software: you can redistribute it and/or modify
+//              it under the terms of the GNU General Public License as published by
+//              the Free Software Foundation, either version 3 of the License, or
+//              (at your option) any later version.
+//
+//              This program is distributed in the hope that it will be useful,
+//              but WITHOUT ANY WARRANTY; without even the implied warranty of
+//              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//              GNU General Public License for more details.
+//
+//              You should have received a copy of the GNU General Public License
+//              along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+//
+extern char *floatString(float v, unsigned char decimals);

--- a/tests/Arduino.h
+++ b/tests/Arduino.h
@@ -1,0 +1,3 @@
+#include <stdio.h>
+#define PSTR(x) x
+#define snprintf_P snprintf

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,6 @@
+These are some unit tests for new methods
+
+To test on a PC:
+
+   c++ -I. testTypes.cpp -o testTypes
+   ./testTypes

--- a/tests/testTypes.cpp
+++ b/tests/testTypes.cpp
@@ -1,0 +1,30 @@
+#include "../SmartRegulator/Types.h"
+#include "../SmartRegulator/Types.cpp"
+
+#include <cassert>
+#include <string.h>
+
+int main(int argc, char *argv[]) {
+	struct {
+		float value;
+		char  precision;
+		const char *expected;
+	} tests[] = {
+		{1.234, 2, "1.23"},
+		{-1.234, 1, "-1.2"},
+		{0.0, 4, "0.0000"},
+		{3.14159265, 6, "3.141592"},
+		{1.9999, 2, "1.99"}		// do we want to round?
+	};
+
+	// test float formatter
+	for ( int t = 0; t < sizeof(tests)/sizeof(tests[0]); t++) {
+		assert(strcmp(floatString(tests[t].value, tests[t].precision), tests[t].expected) == 0);
+	}
+
+	// we don't return the same pointer over and over again
+	// so the data is in a different buffer each time
+	assert(floatString(1.1, 1) != floatString(1.1, 1));
+
+	printf("All tests passed.\n");
+}


### PR DESCRIPTION
NOTE: I haven't tested this on the actual regulator yet! Feel free to hold off until I field test this.

Rather than replicate all the logic for splitting floats
into strings, this change consolidates all that work into
a single method, and removes frac2int.

Code size reduces from 64188 to 63606, saving more
than 500 bytes.

Added some unit test framework so tests can be performed
on the code from a PC.